### PR TITLE
Route stats styling

### DIFF
--- a/build/tasks/bundle.js
+++ b/build/tasks/bundle.js
@@ -3,6 +3,7 @@ const browserifyinc = require('browserify-incremental')
 const buffer = require('vinyl-buffer')
 const cssModulesify = require('css-modulesify')
 const cssNext = require('postcss-cssnext')
+const autoprefixer = require('autoprefixer')
 const envify = require('envify/custom')
 const es3ify = require('es3ify')
 const gulp = require('gulp')
@@ -26,7 +27,7 @@ const BROWSERIFY_OPTS = {
 const CSS_MODULES_OPTS = {
   output: path.join(DEV_DIR, 'main.css'),
   generateScopedName: require('../css-modules-scope-generator'),
-  after: [cssNext]
+  after: [cssNext, autoprefixer]
 }
 
 const clientBundler = browserifyinc(Object.assign({}, BROWSERIFY_OPTS, {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     }
   },
   "devDependencies": {
-    "autoprefixer": "^6.2.3",
+    "autoprefixer": "^6.3.3",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",

--- a/source/Routes/Home/index.js
+++ b/source/Routes/Home/index.js
@@ -160,20 +160,20 @@ export default () => (
         <div className={ styles.contentBox }>
           <TextContent>
             <h3>How far will your team ride?</h3>
-            <Grid spacing="none">
-              <GridItem divisions={['full', 'tablet-one-third']}>
+            <Grid spacing="tight">
+              <GridItem divisions={['one-third']}>
                 <BigStat
                   number="31"
                   label="Days"
                 />
               </GridItem>
-              <GridItem divisions={['full', 'tablet-one-third']}>
+              <GridItem divisions={['one-third']}>
                 <BigStat
                   number="300"
                   label="Teams"
                 />
               </GridItem>
-              <GridItem divisions={['full', 'tablet-one-third']}>
+              <GridItem divisions={['one-third']}>
                 <BigStat
                   number="3,000"
                   label="Miles"

--- a/source/Routes/Home/index.js
+++ b/source/Routes/Home/index.js
@@ -45,26 +45,30 @@ export default () => (
       </CallToActionNavLink>
     </Hero>
 
-    <nav role="navigation" id="mainNavSection">
+    <nav role="navigation" className={ styles.PageNav }>
       <Container>
         <Grid spacing="none">
           <GridItem divisions={['one-quarter']}>
-            <NavLink to="/#about" image="/Routes/Home/greatuscrossing_bike.png">
+            <NavLink to="/#about" className={ styles.PageNav__NavLink }>
+              <img className={ styles.PageNav__NavImage } src="/Routes/Home/greatuscrossing_bike.png" />
               About
             </NavLink>
           </GridItem>
           <GridItem divisions={['one-quarter']}>
-            <NavLink to="/#route" image="/Routes/Home/greatuscrossing_pin.png">
+            <NavLink to="/#route" className={ styles.PageNav__NavLink }>
+              <img className={ styles.PageNav__NavImage } src="/Routes/Home/greatuscrossing_pin.png" />
               Route
             </NavLink>
           </GridItem>
           <GridItem divisions={['one-quarter']}>
-            <NavLink to="/#prizes" image="/Routes/Home/greatuscrossing_trophy.png">
+            <NavLink to="/#prizes" className={ styles.PageNav__NavLink }>
+              <img className={ styles.PageNav__NavImage } src="/Routes/Home/greatuscrossing_trophy.png" />
               Prizes
             </NavLink>
           </GridItem>
           <GridItem divisions={['one-quarter']}>
-            <NavLink to="/#fundraising" image="/Routes/Home/greatuscrossing_hands.png">
+            <NavLink to="/#fundraising" className={ styles.PageNav__NavLink }>
+              <img className={ styles.PageNav__NavImage } src="/Routes/Home/greatuscrossing_hands.png" />
               Fundrasing
             </NavLink>
           </GridItem>

--- a/source/Routes/Home/styles.css
+++ b/source/Routes/Home/styles.css
@@ -20,6 +20,10 @@
   box-shadow: 0 0.25em 0.25em 0 rgba(140, 140, 140, 0.25);
 }
 
+.floatingBox > * {
+  margin: 0;
+}
+
 .contentBox {
   margin-top: 0;
   padding: 2em;
@@ -57,6 +61,7 @@
 }
 
 .PageNav {
+  margin-top: 0;
   background: #003167;
   background-image: linear-gradient(#00689f, #003167);
 }

--- a/source/Routes/Home/styles.css
+++ b/source/Routes/Home/styles.css
@@ -56,13 +56,18 @@
   padding-bottom: 100%;
 }
 
-#mainNavSection {
-    background: #003167; /* For browsers that do not support gradients */
-    background: -webkit-linear-gradient(#00689f, #003167); /* For Safari 5.1 to 6.0 */
-    background: -o-linear-gradient(#00689f, #003167); /* For Opera 11.1 to 12.0 */
-    background: -moz-linear-gradient(#00689f, #003167); /* For Firefox 3.6 to 15 */
-    background: linear-gradient(#00689f, #003167); /* Standard syntax */
+.PageNav {
+  background: #003167;
+  background-image: linear-gradient(#00689f, #003167);
 }
-#mainNavSection * {
-	color: #fff;
+
+.PageNav__NavLink {
+  display: block;
+  text-align: center;
+  color: white;
+}
+
+.PageNav__NavImage {
+  display: block;
+  margin: 0 auto;
 }

--- a/source/components/BigStat/styles.css
+++ b/source/components/BigStat/styles.css
@@ -1,16 +1,35 @@
-.label,
-.number {
-  display: inline-block;
+.base {
+  padding: 0.75em;
+  border: thin solid lightgrey;
 }
 
 .number {
-  font-size: 2.5em;
+  font-size: 1.25em;
+  line-height: 0.9em;
   font-weight: 900;
   margin-right: 0.125em;
 }
 
 .label {
-  margin: 0;
+  margin-top: 0.75em;
+  padding-top: 0.75em;
+  border-top: thin dotted lightgrey;
   text-transform: uppercase;
   font-size: 0.8em;
+  line-height: 0.9em;
+}
+
+@media screen and (min-width: 800px) {
+  .base {
+    padding: 1em;
+  }
+
+  .label {
+    margin-top: 1em;
+    padding-top: 1em;
+  }
+
+  .number {
+    font-size: 2.5em;
+  }
 }

--- a/source/components/Grid/index.js
+++ b/source/components/Grid/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import styles from './styles.css'
-import cssHelpers from '../../css-helpers.css'
 
 class Grid extends React.Component {
   static childContextTypes = {
@@ -19,13 +18,9 @@ class Grid extends React.Component {
 
   render () {
     const { spacing, children } = this.props
-    const classNames = [
-      styles[spacing],
-      cssHelpers.clearfix
-    ].join(' ')
 
     return (
-      <div className={ classNames }>
+      <div className={ styles[spacing] }>
         { children }
       </div>
     )

--- a/source/components/Grid/styles.css
+++ b/source/components/Grid/styles.css
@@ -1,4 +1,5 @@
 .base {
+  composes: clearfix from '../../css-helpers.css';
   margin-bottom: 0;
 }
 

--- a/source/components/Hero/styles.css
+++ b/source/components/Hero/styles.css
@@ -1,4 +1,5 @@
 .base {
+  margin-top: 0;
   position: relative;
   text-align: center;
   padding-top: 1.5em;

--- a/source/components/NavLink/index.js
+++ b/source/components/NavLink/index.js
@@ -1,12 +1,10 @@
 import { Link } from 'react-router'
 import React from 'react'
 import config from '../../../config/environment'
-import styles from './styles.css'
 
 const { client: { basePath }} = config
 
 export default (props) => (
-  <center><img className={ styles.image } src={ props.image } /></center>
   <Link
     { ...props }
     to={ `${ basePath }${ props.to }` }

--- a/source/components/NavLink/styles.css
+++ b/source/components/NavLink/styles.css
@@ -1,5 +1,0 @@
-.image {
-	width: 80%;
-	display: block;
-	position: relative;
-}

--- a/source/components/PrizeCategory/styles.css
+++ b/source/components/PrizeCategory/styles.css
@@ -3,7 +3,7 @@
   text-align: center;
 }
 
-.base * + * {
+.base p {
   margin-top: 0;
 }
 

--- a/source/components/Section/index.js
+++ b/source/components/Section/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Container from '../Container'
 import styles from './styles.css'
 
-export default ({ id, background, children, theme = 'base' }) => (
+export default ({ id, background, children, theme = 'default' }) => (
   <section id={ id } className={ styles[theme] }>
     { !!background &&
       <div className={ styles.background }>

--- a/source/components/Section/styles.css
+++ b/source/components/Section/styles.css
@@ -10,7 +10,16 @@
   height: 100%;
 }
 
+.default {
+  composes: base;
+}
+
+.default h2 {
+  color: #bb1c3f;
+}
+
 .darkBlue {
+  composes: base;
   background-color: #001e2c;
   color: white;
 }

--- a/source/components/Section/styles.css
+++ b/source/components/Section/styles.css
@@ -1,4 +1,5 @@
 .base {
+  margin: 0;
   position: relative;
 }
 

--- a/source/components/Steps/Step/styles.css
+++ b/source/components/Steps/Step/styles.css
@@ -4,7 +4,7 @@
   text-align: center;
 }
 
-.base * + * {
+.base p {
   margin-top: 0;
 }
 

--- a/source/components/TextContent/styles.css
+++ b/source/components/TextContent/styles.css
@@ -1,8 +1,3 @@
-.base * + * {
-  margin-bottom: 0;
-  margin-top: 1.5em;
-}
-
 .base h1,
 .base h2,
 .base h3,
@@ -44,6 +39,7 @@
 }
 
 .default { composes: base; }
+
 .alignCenter {
   composes: base;
   text-align: center;

--- a/source/layouts/Document/index.js
+++ b/source/layouts/Document/index.js
@@ -5,7 +5,7 @@ export default ({ title, content }) => (
   <html>
     <head>
       <title>{ title }</title>
-      <meta charset="utf-8" />
+      <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.2/es5-shim.min.js" />

--- a/source/layouts/Document/styles.css
+++ b/source/layouts/Document/styles.css
@@ -11,6 +11,18 @@
   margin: 0;
 }
 
+:global * {
+  margin: 0;
+}
+
+:global * + * {
+  margin-top: 1.5em;
+}
+
+:global main {
+  margin: 0;
+}
+
 a {
   text-decoration: none;
   color: #4c80a5;

--- a/source/layouts/Footer/styles.css
+++ b/source/layouts/Footer/styles.css
@@ -1,4 +1,5 @@
 .base {
+  margin-top: 0;
   text-align: center;
   background: #00405f;
   color: white;

--- a/source/vendor.scss
+++ b/source/vendor.scss
@@ -16,7 +16,6 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
-  margin: 0;
   padding: 0;
   border: 0;
   font-size: 100%;


### PR DESCRIPTION
Put the route stats in little styled boxes. Helps to make them interfere less with the rest of the type. Hopefully.

<img width="423" alt="screen shot 2016-03-02 at 2 16 07 pm" src="https://cloud.githubusercontent.com/assets/3494751/13450586/b2a51034-e082-11e5-99bd-258991847e13.png">
<img width="1072" alt="screen shot 2016-03-02 at 2 16 30 pm" src="https://cloud.githubusercontent.com/assets/3494751/13450585/b2a30b4a-e082-11e5-98ad-634325d6493e.png">
